### PR TITLE
fmono: views and partials

### DIFF
--- a/fmono/.gitignore
+++ b/fmono/.gitignore
@@ -1,2 +1,3 @@
 public
 coverage
+*0x*

--- a/fmono/package-lock.json
+++ b/fmono/package-lock.json
@@ -559,6 +559,12 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/ejs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.0.tgz",
+      "integrity": "sha512-DCg+Ka+uDQ31lJ/UtEXVlaeV3d6t81gifaVWKJy4MYVVgvJttyX/viREy+If7fz+tK/gVxTGMtyrFPnm4gjrVA==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.4.tgz",
@@ -667,7 +673,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -893,8 +898,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -970,7 +974,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1300,7 +1303,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1311,7 +1313,6 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -1408,7 +1409,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1416,8 +1416,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.6.0",
@@ -1495,8 +1494,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -2125,6 +2123,14 @@
         }
       }
     },
+    "ejs": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+      "requires": {
+        "jake": "^10.6.1"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.857",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.857.tgz",
@@ -2211,8 +2217,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "7.32.0",
@@ -2540,6 +2545,11 @@
       "resolved": "https://registry.npmjs.org/fastify-error/-/fastify-error-0.3.1.tgz",
       "integrity": "sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ=="
     },
+    "fastify-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.0.tgz",
+      "integrity": "sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w=="
+    },
     "fastify-warning": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
@@ -2566,6 +2576,14 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
+      }
+    },
+    "filelist": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+      "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
       }
     },
     "fill-range": {
@@ -2838,8 +2856,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -2873,6 +2890,11 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
     "hdr-histogram-js": {
       "version": "2.0.1",
@@ -3220,6 +3242,24 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "jake": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
+      "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+      "requires": {
+        "async": "0.9.x",
+        "chalk": "^2.4.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        }
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -3650,7 +3690,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4163,6 +4202,15 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
       "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+    },
+    "point-of-view": {
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/point-of-view/-/point-of-view-4.15.2.tgz",
+      "integrity": "sha512-4HH/lJRBx8dzFjK5EiK+m459Bkw85GDuRnbk9qnxjQfUg0HYADQvJU73lLxZlHO2G4f9KvslOoTbdBx51mlDdg==",
+      "requires": {
+        "fastify-plugin": "^3.0.0",
+        "hashlru": "^2.3.0"
+      }
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/fmono/package.json
+++ b/fmono/package.json
@@ -8,13 +8,16 @@
     "web": "https://github.com/gfogle"
   },
   "dependencies": {
-    "fastify": "3.21.6"
+    "ejs": "3.1.6",
+    "fastify": "3.21.6",
+    "point-of-view": "4.15.2"
   },
   "description": "Monolith Fastify ",
   "devDependencies": {
     "0x": "4.11.0",
     "@hapi/code": "8.0.3",
     "@hapi/lab": "24.3.2",
+    "@types/ejs": "3.1.0",
     "@types/node": "14.14.16",
     "apidoc": "0.29.0",
     "autocannon": "7.4.0",
@@ -45,7 +48,7 @@
     "docs": "./node_modules/.bin/apidoc -i src -o public",
     "lint": "./node_modules/.bin/tsc --diagnostics --noEmit",
     "profile": "PORT=4000 ./node_modules/.bin/0x -o src/server.js",
-    "perf": "PORT=4000 ./node_modules/.bin/0x -P 'autocannon localhost:4000/health' src/server.js",
+    "perf": "PORT=4000 ./node_modules/.bin/0x -P 'autocannon localhost:4000' src/server.js",
     "test": "./node_modules/.bin/lab -r html -o test/coverage/index.html -r console -o stdout"
   },
   "version": "0.1.0"

--- a/fmono/src/plugins/home/controllers/home.controller.js
+++ b/fmono/src/plugins/home/controllers/home.controller.js
@@ -1,0 +1,21 @@
+class HomeController {
+  /**
+   *
+   * @param {import("fastify").FastifyRequest} request
+   * @param {import("fastify").FastifyReply} reply
+   */
+  index(request, reply) {
+    reply.statusCode = 200;
+    reply.view(`plugins/home/views/index.ejs`, {
+      title: "FMono | Fastify Monorepo",
+      description: "Homepage for FMono, a monorepo built with FastifyJS.",
+      partials: {
+        header: "../../shared/views/partials/_header.ejs",
+        meta: "../../shared/views/partials/_meta.ejs",
+        polyfills: "../../shared/views/partials/_polyfills.ejs",
+      },
+    });
+  }
+}
+
+module.exports.HomeController = HomeController;

--- a/fmono/src/plugins/home/index.js
+++ b/fmono/src/plugins/home/index.js
@@ -1,0 +1,22 @@
+const { HomeController } = require("./controllers/home.controller");
+
+const homeController = new HomeController();
+
+/**
+ *
+ * @param {import('fastify').FastifyInstance} fastify
+ * @param {*} opts
+ * @param {Function} done
+ */
+module.exports = function (fastify, opts, done) {
+  /**
+   * @api {get} /health
+   * @apiDescription health check endpoint
+   * @apiGroup Health
+   * @apiName GetHealth
+   * @apiSampleRequest http://localhost:4000/health
+   */
+  fastify.get("/", homeController.index);
+
+  done();
+};

--- a/fmono/src/plugins/home/views/index.ejs
+++ b/fmono/src/plugins/home/views/index.ejs
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- TODO: this could be a shared partial with an injected value -->
+    <title><%= title %></title>
+    <meta name="description" content="<%= description %>"></meta>
+
+    <%- include(partials.meta); %>
+  </head>
+
+  <body>
+    <%- include(partials.header); %>
+
+    <div id="mount"></div>
+
+    <%- include(partials.polyfills); %>
+
+    <script type="importmap">
+      {
+        "imports": {
+          "preact": "https://cdn.skypack.dev/preact",
+          "htm": "https://cdn.skypack.dev/htm"
+        }
+      }
+    </script>
+
+    <script type="module">
+      import { h, Component, render } from "preact";
+      import htm from "htm";
+
+      const html = htm.bind(h);
+
+      function Carousel(props) {
+        return html`
+          <section>A carousel would go here</section>
+        `;
+      }
+
+      function App(props) {
+        return html`
+          <h1>Hello, ${props.name}!</h1>
+          <${Carousel} />
+        `;
+      }
+
+      render(html`<${App} name="World" />`, document.getElementById("mount"));
+    </script>
+  </body>
+</html>

--- a/fmono/src/plugins/shared/index.js
+++ b/fmono/src/plugins/shared/index.js
@@ -1,0 +1,9 @@
+/**
+ *
+ * @param {import('fastify').FastifyInstance} fastify
+ * @param {*} opts
+ * @param {Function} done
+ */
+module.exports = function (fastify, opts, done) {
+  done();
+};

--- a/fmono/src/plugins/shared/views/partials/_header.ejs
+++ b/fmono/src/plugins/shared/views/partials/_header.ejs
@@ -1,0 +1,323 @@
+<nav aria-label="Main Menu">
+  <style>
+    :root {
+      --dark: #1c2a39;
+      --nav-height: 82px;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      width: 100vw;
+    }
+
+    * {
+      color: var(--dark);
+    }
+
+    a {
+      text-decoration: none;
+      display: block;
+    }
+
+    a:hover,
+    a:focus {
+      text-decoration: underline;
+    }
+
+    nav {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      align-items: center;
+      position: relative;
+      height: var(--nav-height);
+    }
+
+    #links {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      align-items: center;
+      justify-content: flex-end;
+      width: 100%;
+    }
+
+    #links li {
+      margin: 0 10px;
+    }
+
+    @media screen and (max-width: 767px) {
+      #links {
+        visibility: hidden;
+        position: absolute;
+        top: var(--nav-height);
+        right: -100vw;
+        width: 0;
+        overflow: hidden;
+        height: calc(100vh - var(--nav-height));
+        flex-direction: column;
+        justify-content: flex-start;
+        background: #fff;
+      }
+
+      #links li {
+        width: 100%;
+        margin-bottom: 10px;
+      }
+
+      #links a {
+        text-align: center;
+        min-height: 50px;
+        padding: 10px;
+        line-height: 26px;
+        font-size: 20px;
+      }
+
+      #links a.btn {
+        margin: 10px;
+      }
+    }
+
+    #hamburger[aria-expanded="true"] ~ #links {
+      visibility: visible;
+      left: 0;
+      width: 100vw;
+    }
+
+    .icon {
+      fill: var(--dark);
+    }
+
+    #link-home {
+      display: inline-block;
+    }
+
+    #link-home svg {
+      width: 160px;
+    }
+
+    @media screen and (max-width: 767px) {
+      #link-home {
+        width: 100%;
+      }
+
+      #link-home svg {
+        width: 260px;
+      }
+    }
+
+    #link-cart {
+      padding: 9px;
+      /* makes it 44px total for WCAG w/o shrinking svg */
+    }
+
+    #link-cart svg {
+      width: 26px;
+      margin-top: 3px;
+    }
+
+    @media screen and (max-width: 767px) {
+      #link-cart {
+        margin: 0 10px;
+        padding: 4px;
+        /* makes it 44px total for WCAG w/o shrinking svg */
+      }
+
+      #link-cart svg {
+        width: 40px;
+        margin-top: 3px;
+      }
+    }
+
+    #hamburger {
+      visibility: hidden;
+      width: 0;
+      height: 0;
+      border: none;
+      padding: 0;
+      margin: 0;
+      overflow: hidden;
+    }
+
+    @media screen and (max-width: 767px) {
+      #hamburger {
+        visibility: visible;
+        border: none;
+        background: none;
+        width: auto;
+        height: 44px;
+        overflow: visible;
+        padding: 4px;
+
+        transition: all 0.25s ease-in-out;
+      }
+
+      #hamburger div {
+        width: 44px;
+        height: 6px;
+        border-radius: 6px;
+        background: var(--dark);
+        position: relative;
+
+        transition: all 0.25s ease-in-out;
+      }
+
+      #hamburger div::before,
+      #hamburger div::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        width: 44px;
+        height: 6px;
+        border-radius: 6px;
+        background: var(--dark);
+
+        transition: all 0.25s ease-in-out;
+      }
+
+      #hamburger div::before {
+        transform: translateY(-16px);
+      }
+
+      #hamburger div::after {
+        transform: translateY(16px);
+      }
+
+      #hamburger[aria-expanded="true"] div {
+        background: transparent;
+      }
+
+      #hamburger[aria-expanded="true"] div::before {
+        transform: rotate(45deg) translate(0, 0);
+      }
+
+      #hamburger[aria-expanded="true"] div::after {
+        transform: rotate(-45deg) translate(0, 0);
+      }
+    }
+
+    .btn {
+      border: none;
+      white-space: nowrap;
+      padding: 9px 18px;
+      text-decoration: none;
+    }
+
+    .btn--rounded {
+      border-radius: 18px;
+    }
+
+    .btn__primary {
+      background-color: var(--dark);
+      color: #fff;
+    }
+
+    .btn__bordered--primary {
+      border: solid 2px var(--dark);
+      color: var(--dark);
+      padding: 7px 16px;
+    }
+  </style>
+
+  <!-- TODO: aria-current -->
+
+  <a id="link-home" href="/" aria-label="Home">
+    <svg
+      class="icon"
+      role="presentation"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 400 120.9"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M28 18l-16 6-1 42c0 49-3 45 21 36l16-6 17 6c20 8 17 8 38-1l18-7V52c0-48 2-45-22-35l-16 7-16-7c-20-8-18-8-39 1m17 69L19 98l-1-34V31l14-5 13-6 1 33-1 34m22-61l12 5 1 34-1 33-14-5-13-5V55l1-34 14 5m46 28v34l-14 5-14 6 1-34V32l13-5 13-6c1 0 2 15 1 33m64-12c-6 6-7 28-1 35 5 6 17 6 22 0 9-12 2-40-11-40-4 0-7 2-10 5m121 0c-6 6-7 28-1 35 4 6 17 6 21 0 10-12 3-40-10-40-4 0-8 2-10 5m35-1c-12 11-5 43 8 40l10-1c5 0 5 0 5-12V57h-8c-5 0-7 0-7 3 0 2 2 4 3 4 3 0 4 6 0 9s-6-2-6-14 3-18 7-11c2 5 11 5 11 0 0-9-16-14-23-7m30 1c-5 6-6 28-1 35 5 6 17 6 22 0 10-12 2-40-11-40-3 0-7 2-10 5m-223-2l6 14c3 7 5 15 5 19 0 6 1 7 5 7s4-1 4-8c0-5 2-12 5-20 7-14 7-13 0-13-4 0-5 1-7 7l-2 6-3-6c-2-6-13-11-13-6m64 17c0 21 2 24 14 24s14-3 15-24V39h-11v17c0 13 0 17-2 18-5 1-7-5-7-21 0-14 0-14-4-14-5 0-5 0-5 18m31 3v20h5c5 0 5 0 5-8 0-7 1-8 4-8s3 1 3 8c0 8 1 8 6 8h6l-1-8-3-10c-1-1-1-3 1-5 8-8 1-18-15-18h-11v21m32 0v20h12c11 0 13 0 13-4 0-3-2-3-8-3h-7V39h-10v21m-76-8c3 14-4 30-8 16-2-5-1-19 1-22s5 0 7 6m121 0c3 14-5 30-8 16-2-5-1-19 1-22s5 0 7 6m66 0c3 14-5 30-9 16-1-5 0-19 2-22s5 0 7 6m-126-2c1 4-2 7-5 7l-2-6c0-6 6-7 7-1"
+      />
+    </svg>
+  </a>
+
+  <button
+    id="hamburger"
+    aria-expanded="false"
+    aria-label="Menu"
+    aria-controls="links"
+    aria-haspopup="true"
+  >
+    <div></div>
+  </button>
+
+  <ul id="links">
+    <li>
+      <a href="#">link</a>
+    </li>
+
+    <li>
+      <a href="#">link</a>
+    </li>
+
+    <li>
+      <a href="#">link</a>
+    </li>
+
+    <li>
+      <a href="#">link</a>
+    </li>
+
+    <li>
+      <a
+        href="/login"
+        class="btn btn--medium btn--rounded btn__bordered--primary"
+        >login</a
+      >
+    </li>
+
+    <li>
+      <a href="#" class="btn btn--medium btn--rounded btn__primary"
+        >call to action</a
+      >
+    </li>
+  </ul>
+
+  <a id="link-cart" href="#" aria-label="Cart">
+    <!-- Pre-optimized icon made by https://www.flaticon.com/authors/dave-gandy" -->
+    <svg
+      role="presentation"
+      id="icon__cart"
+      class="icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewbox="0 0 475.1 475.1"
+    >
+      <path
+        d="M365 402c0 10 4 19 11 26s16 11 26 11 19-4 26-11 11-16 11-26-4-19-11-26-16-11-26-11-19 4-26 11-11 16-11 26zM470 79c-4-4-8-6-13-6H114a205 205 0 00-5-23l-4-7a18 18 0 00-14-6H18c-5 0-9 1-13 5-3 4-5 8-5 13s2 9 5 13c4 3 8 5 13 5h59l50 235a782 782 0 01-14 28l-3 11c0 5 1 9 5 13s8 5 13 5h292c5 0 9-1 13-5s6-8 6-13-2-9-6-13c-4-3-8-5-13-5H158l6-18v-7l-2-7-1-6 298-35c5-1 8-3 12-6 3-4 4-8 4-12V91c0-5-2-9-5-12zM110 402a35 35 0 0037 37c9 0 18-4 25-11s11-16 11-26-4-19-11-26-16-11-26-11-19 4-26 11-10 16-10 26z"
+      />
+    </svg>
+  </a>
+
+  <script>
+    (function (d) {
+      // TODO: only do this on mobile
+      var hamburger = d.getElementById("hamburger");
+      var links = d.getElementById("links");
+      var cart = d.getElementById("link-cart");
+
+      hamburger &&
+        hamburger.addEventListener("click", function () {
+          this.getAttribute("aria-expanded") == "false"
+            ? this.setAttribute("aria-expanded", "true")
+            : this.setAttribute("aria-expanded", "false");
+        });
+
+      links && links.setAttribute("role", "menu");
+      cart &&
+        cart.addEventListener("focus", function () {
+          if (hamburger) {
+            hamburger.setAttribute("aria-expanded", "false");
+          }
+        });
+    })(document);
+  </script>
+</nav>

--- a/fmono/src/plugins/shared/views/partials/_meta.ejs
+++ b/fmono/src/plugins/shared/views/partials/_meta.ejs
@@ -1,0 +1,4 @@
+
+<meta charset="utf-8"></meta>
+<meta http-equiv="X-UA-Compatible" content="IE=edge"></meta>
+<meta name="viewport" content="width=device-width, height=device-height, initial-scale=1"></meta>

--- a/fmono/src/plugins/shared/views/partials/_polyfills.ejs
+++ b/fmono/src/plugins/shared/views/partials/_polyfills.ejs
@@ -1,0 +1,1 @@
+<script src="https://polyfill.io/v3/polyfill.min.js?flags=gated&unknown=polyfill"></script>

--- a/fmono/src/server.js
+++ b/fmono/src/server.js
@@ -1,11 +1,20 @@
 const fs = require("fs");
 const { fastify: Fastify } = require("fastify");
 
-const fastify = Fastify({
-  logger: true,
-});
-
 if (process.env.PORT) {
+  const fastify = Fastify({
+    logger: true,
+  });
+
+  /** @type any */
+  const pov = require("point-of-view");
+  fastify.register(pov, {
+    engine: {
+      ejs: require("ejs"),
+    },
+    root: __dirname,
+  });
+
   for (const p of fs.readdirSync("./src/plugins")) {
     try {
       fastify.register(require(`${__dirname}/plugins/${p}`));


### PR DESCRIPTION
# Description
Adds a `home` and `shared` partial to demonstrate a "homepage" but also using global partials an app would expect to have like a `<nav>` and various tags that go in the `<head>`. 

Its not a perfect solution because the include paths are very opinionated so I moved them into the controller because theoretically these are best generated programmatically.

The homepage also uses import maps and esm to render a preact + htm application to show client-side rendering.

## Screenshots

** UI **
<img width="1280" alt="Screen Shot 2021-10-02 at 11 40 24 PM" src="https://user-images.githubusercontent.com/7015773/135738584-2a64d2fe-910b-498b-ae0a-52e1c634b668.png">

** Flamegraph of /health **
<img width="1278" alt="Screen Shot 2021-10-02 at 11 45 07 PM" src="https://user-images.githubusercontent.com/7015773/135738774-899baa50-7094-4cf5-82fc-6191055b2af2.png">

** Performance of /health **
<img width="775" alt="Screen Shot 2021-10-02 at 11 45 58 PM" src="https://user-images.githubusercontent.com/7015773/135738776-aafd2804-4d40-4e86-a31c-40dcec1aa9fa.png">

** Flamegraph of / **
<img width="1275" alt="Screen Shot 2021-10-02 at 11 48 31 PM" src="https://user-images.githubusercontent.com/7015773/135738821-23e7ac78-13bd-4d63-a156-c101e77701e8.png">

** Performance of / **
NODE_ENV=development
<img width="827" alt="Screen Shot 2021-10-02 at 11 47 53 PM" src="https://user-images.githubusercontent.com/7015773/135738831-a6e4da1e-5ac3-40a8-8b62-c4a78ba6bbf7.png">

NODE_ENV=production ( caches templates etc. )
<img width="828" alt="Screen Shot 2021-10-02 at 11 51 37 PM" src="https://user-images.githubusercontent.com/7015773/135738880-a2cb1890-21e6-45d7-8007-c480e2131bc8.png">
